### PR TITLE
Rework stress gained while shooting

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -592,7 +592,7 @@ lib.onCache('weapon', function(weapon)
             local isShooting = IsPedShooting(player)
             if isShooting then
                 if math.random() < Config.StressChance then
-                    TriggerEvent('hud:client:GainStress', math.random(1, 3))
+                    updateStress(math.random(1, 3), true)
                 end
             end
             Wait(0)


### PR DESCRIPTION
Rework weapon on hands tracking and efficiently tracks when player is shooting for stress handling. Automatically stop thread when player is not using any weapons.

https://medal.tv/games/red-dead-2/clips/ljzEdB0XAuD-eJePB?invite=cr-MSw5angsMzQ3MzIwMzMw